### PR TITLE
Adds collection name to length check error; upgrades mongo driver

### DIFF
--- a/lib/fixtures.coffee
+++ b/lib/fixtures.coffee
@@ -41,7 +41,7 @@ cleanAndLoad = (db, collectionName, documents, callback) ->
         
         removeAll   = (next) -> collection.remove {}, next
         insertData  = (next) -> insertAll collection, documents, next
-        verify      = (next) -> checkCollectionLength collection, documents.length, next
+        verify      = (next) -> checkCollectionLength collection, collectionName, documents.length, next
         log         = (next) -> console.log("Inserted #{documents.length} #{collectionName}"); next();
         
         async.series [removeAll, insertData, verify, log], callback
@@ -54,10 +54,10 @@ insertAll = (collection, documents, callback) ->
 
     async.parallel operations, callback
 
-checkCollectionLength = (collection, expectedLength, callback) ->
+checkCollectionLength = (collection, name, expectedLength, callback) ->
     collection.find().toArray (err, inserted) ->
         if err
             callback(err)
         else if inserted.length != expectedLength
-            callback("Failed: inserted #{inserted.length} but expected #{expectedLength}")
+            callback("Failed: inserted #{inserted.length} into #{name} but expected #{expectedLength}")
         else callback(null)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "async": "0.1.x",
         "underscore": "1.4.x",
-        "mongodb": "1.1.x",
+        "mongodb": "2.0.x",
         "wrench": "1.3.x",
         "async": "0.1.x",
         "prompt": "0.2.x"


### PR DESCRIPTION
Was seeing some strange behavior with duplicated ObjectIds using the old mongo driver, which an upgrade resolved.

I also added the collection name when logging about an length mismatch. (BTW. The version of this package published on npm uses 'collection.length' which throws an error. If you could publish this version soon that would be appreciated)
