### PR TITLE
Modifies shrinkwrap for mongodb-upgrade

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,120 +3,175 @@
   "version": "0.0.2",
   "dependencies": {
     "async": {
-      "version": "0.1.22"
-    },
-    "underscore": {
-      "version": "1.4.4"
+      "version": "0.1.22",
+      "from": "async@0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
     },
     "mongodb": {
-      "version": "1.1.11",
+      "version": "2.0.35",
+      "from": "mongodb@2.0.X",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.35.tgz",
       "dependencies": {
-        "bson": {
-          "version": "0.1.5"
+        "mongodb-core": {
+          "version": "1.2.2",
+          "from": "mongodb-core@1.2.2",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.2.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "0.4.7",
+              "from": "bson@~0.4",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.7.tgz"
+            },
+            "kerberos": {
+              "version": "0.0.12",
+              "from": "kerberos@~0.0",
+              "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.12.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "from": "nan@~1.8",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.31",
+          "from": "readable-stream@1.0.31",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@~0.10.x",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@~2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
         }
       }
     },
-    "wrench": {
-      "version": "1.3.9"
-    },
     "prompt": {
       "version": "0.2.9",
+      "from": "prompt@0.2.9",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.9.tgz",
       "dependencies": {
         "pkginfo": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "from": "pkginfo@0.3.0",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
         },
         "read": {
           "version": "1.0.4",
+          "from": "read@1.0.4",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.4.tgz",
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.3"
+              "version": "0.0.3",
+              "from": "mute-stream@0.0.3",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz"
             }
           }
         },
         "revalidator": {
-          "version": "0.1.5"
+          "version": "0.1.5",
+          "from": "revalidator@0.1.5",
+          "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.5.tgz"
         },
         "utile": {
           "version": "0.1.7",
+          "from": "utile@0.1.7",
+          "resolved": "https://registry.npmjs.org/utile/-/utile-0.1.7.tgz",
           "dependencies": {
             "deep-equal": {
-              "version": "0.0.0"
+              "version": "0.0.0",
+              "from": "deep-equal@0.0.0",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "i": {
-              "version": "0.3.1"
+              "version": "0.3.1",
+              "from": "i@0.3.1",
+              "resolved": "https://registry.npmjs.org/i/-/i-0.3.1.tgz"
             },
             "mkdirp": {
-              "version": "0.3.5"
+              "version": "0.3.5",
+              "from": "mkdirp@0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "ncp": {
-              "version": "0.2.7"
+              "version": "0.2.7",
+              "from": "ncp@0.2.7",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.2.7.tgz"
             },
             "rimraf": {
-              "version": "1.0.9"
+              "version": "1.0.9",
+              "from": "rimraf@1.0.9",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-1.0.9.tgz"
             }
           }
         },
         "winston": {
           "version": "0.6.2",
+          "from": "winston@0.6.2",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
           "dependencies": {
             "colors": {
-              "version": "0.6.0-1"
+              "version": "0.6.0-1",
+              "from": "colors@0.6.0-1",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
             },
             "cycle": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "cycle@1.0.2",
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.2.tgz"
             },
             "eyes": {
-              "version": "0.1.8"
+              "version": "0.1.8",
+              "from": "eyes@0.1.8",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
-              "version": "0.2.3"
+              "version": "0.2.3",
+              "from": "pkginfo@0.2.3",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
             },
             "request": {
-              "version": "2.9.203"
+              "version": "2.9.203",
+              "from": "request@2.9.203",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
             },
             "stack-trace": {
-              "version": "0.0.6"
+              "version": "0.0.6",
+              "from": "stack-trace@0.0.6",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.6.tgz"
             }
           }
         }
       }
     },
-    "coffee-script": {
-      "version": "1.3.3"
+    "underscore": {
+      "version": "1.4.4",
+      "from": "underscore@1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
     },
-    "should": {
-      "version": "1.2.0"
-    },
-    "mocha": {
-      "version": "1.5.0",
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1"
-        },
-        "growl": {
-          "version": "1.5.1"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.3.0"
-            }
-          }
-        },
-        "diff": {
-          "version": "1.0.2"
-        },
-        "debug": {
-          "version": "0.7.2"
-        },
-        "mkdirp": {
-          "version": "0.3.3"
-        },
-        "ms": {
-          "version": "0.3.0"
-        }
-      }
+    "wrench": {
+      "version": "1.3.9",
+      "from": "wrench@1.3.9",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz"
     }
   }
 }


### PR DESCRIPTION
Hey. In my PR yesterday, I didn't realize you were using shrinkwrap so your newest published version is still install the v1 version of the mongo driver. Here's the shrinkwrapped version. Sorry about that.
